### PR TITLE
only set `height: auto` for images without height attributes

### DIFF
--- a/scss/core/global/_images.scss
+++ b/scss/core/global/_images.scss
@@ -9,8 +9,11 @@
  * width:; and height:; above apply
  */
 img, embed, object, video {
-  height: auto;
   max-width: 100%;
+
+  &:not([height]) {
+    height: auto;
+  }
 }
 
 /**


### PR DESCRIPTION
ensures that if a height is set via an attribute, that that attribute is respected