### PR TITLE
fix(core _images.scss): revert height: auto update

### DIFF
--- a/scss/core/global/_images.scss
+++ b/scss/core/global/_images.scss
@@ -10,10 +10,7 @@
  */
 img, embed, object, video {
   max-width: 100%;
-
-  &:not([height]) {
-    height: auto;
-  }
+  height: auto;
 }
 
 /**


### PR DESCRIPTION
using `img:not([height])` adds specificity to `img` which can't be overridden by a class with low specificity