### PR TITLE
chore(.travis.yml): don't use 'node'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
   - 10
-  - node
+  - 12
+  - 14
 
 jobs:
   include:


### PR DESCRIPTION
the `node` version in Travis is failing - this removes that version