### PR TITLE
fix(entrypoint): custom support and globals should immediately overri…

### DIFF
--- a/scss/custom/_index.scss
+++ b/scss/custom/_index.scss
@@ -2,16 +2,6 @@
     CUSTOM STYLES
 \*------------------------------------*/
 /**
- * Import custom variables, mixins, and functions
- */
-@import "support";
-
-/**
- * Import custom global styles
- */
-@import "global";
-
-/**
  * Import custom styles
  */
 @import "app";

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -4,11 +4,15 @@
   STYLES ENTRYPOINT
 \*------------------------------------*/
 /**
- * Import core support files and globals
+ * Import core files, overriding each with custom styles
  */
 @import "core/support";
+@import "custom/support";
+
 @import "reset";
+
 @import "core/global";
+@import "custom/global";
 
 /**
  * Import custom styles to override core


### PR DESCRIPTION
core globals were being imported before custom support files - custom variables were defined _after_ processing global core styles, resulting in global core styles not using custom variables