### PR TITLE
only remove margin of immediate children

### DIFF
--- a/scss/core/tools/mixins/components/_alerts.scss
+++ b/scss/core/tools/mixins/components/_alerts.scss
@@ -6,8 +6,8 @@
   padding: px-to-rem($spacing-scalar * $fs-base);
 
 
-  & p:last-child,
-  & ul:last-child { margin-block-end: 0;}
+  & > p:last-child,
+  & > ul:last-child { margin-block-end: 0;}
 }
 
   @mixin f8-alert__close {


### PR DESCRIPTION
margin was being removed from every last child in an alert, including last children of nested elements.

This PR ensures that the child must be an immediate child of the alert